### PR TITLE
8143-DHL-Payors => master

### DIFF
--- a/ShipperOptions.json
+++ b/ShipperOptions.json
@@ -1857,7 +1857,7 @@
         "display": "Biological UN3373"
       }
     ],
-    "duty_payment_types": [
+    "payor": [
       {
         "value": "S",
         "display": "Shipper"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ordoro/shipper-options",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A collection of shipper options",
   "main": "ShipperOptions.json",
   "scripts": {


### PR DESCRIPTION
### Switch to `payor` for DHL payor list

- This will be used for postage payment and duties payment

ordoro/ordoro#8134

ordoro/shipper-options@b4f8f872e62a464e312a1940a1ca2dd907cd0f90

___

### 1.2.0

ordoro/shipper-options@db9cca42cfbeb660bfc33cde8871426908073abc