### PR TITLE
9216-remove-dead-visible-box-types => master

### DIFF
--- a/ShipperOptions.json
+++ b/ShipperOptions.json
@@ -2303,20 +2303,8 @@
         "display": "Parcel"
       },
       {
-        "value": "OversizedParcel",
-        "display": "Oversized Parcel"
-      },
-      {
         "value": "Letter",
         "display": "Letter"
-      },
-      {
-        "value": "Softpack",
-        "display": "Softpack"
-      },
-      {
-        "value": "Flat",
-        "display": "Flat"
       },
       {
         "value": "Envelope",
@@ -2341,10 +2329,6 @@
       {
         "value": "RegionalRateBoxB",
         "display": "Regional Rate Box B"
-      },
-      {
-        "value": "RegionalRateBoxC",
-        "display": "Regional Rate Box C"
       }
     ],
     "shipping_method": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ordoro/shipper-options",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "A collection of shipper options",
   "main": "ShipperOptions.json",
   "scripts": {


### PR DESCRIPTION
### Visible USPS - has old box types that do not work

- Remove them until they can tell us that they should work or they update their list to reflect USPS changes

ordoro/ordoro#9216

ordoro/shipper-options@8ab419005bc8b55aea922612319bbdf37d9ad535