### PR TITLE
5724-Australia-Post => master

### DIFF
--- a/ShipperOptions.json
+++ b/ShipperOptions.json
@@ -3,7 +3,27 @@
     "display_name": "Other"
   },
   "australia_post": {
-    "display_name": "Australia Post"
+    "display_name": "Australia Post",
+    "box_shape": [
+      {"display": "Parcel", "value": "PKG"}
+    ],
+    "shipping_method": [
+      {"display": "Express Post", "value": "ExpressPost"},
+      {"display": "Express Post w/ Signature", "value": "ExpressPostSignature"},
+      {"display": "Parcel Post", "value": "ParcelPost"},
+      {"display": "Parcel Post w/ Signature", "value": "ParcelPostSignature"},
+      {"display": "Parcel Post Extra", "value": "ParcelPostExtra"},
+      {"display": "Parcel Post Wine + Signature", "value": "ParcelPostWinePlusSignature"},
+      {"display": "Priority", "value": "Priority", "comment": "Added so we can get rates from EasyPost"}
+    ],
+    "reason_for_export": [
+      {"display": "Merchandise", "value": "merchandise"},
+      {"display": "Documents", "value": "documents"},
+      {"display": "Gift", "value": "gift"},
+      {"display": "Returned Goods", "value": "returned_goods"},
+      {"display": "Commercial Sample", "value": "sample"},
+      {"display": "Other", "value": "other" }
+    ]
   },
   "canada_post": {
     "service_option": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ordoro/shipper-options",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "description": "A collection of shipper options",
   "main": "ShipperOptions.json",
   "scripts": {


### PR DESCRIPTION
### Added Australia Post shipper options

- Added generic shipping_method because we can't get real Australia Post
  rates, `Priority` is not a real shipping method for the Aussies

ordoro/ordoro#5724

ordoro/shipper-options@304f0858ff663838f4a0b6d209d7deefe499b834

___

### 1.5.0

ordoro/shipper-options@9654fc013c3815b4b131bf86f4f0e3e3054ea5f3