### PR TITLE
9309-Remove-Dup-Options => master

### DIFF
--- a/ShipperOptions.json
+++ b/ShipperOptions.json
@@ -2189,34 +2189,6 @@
         "display": "USPS Bound Printed Matter"
       },
       {
-        "value": "USPS_PTP_EXP_LFRE",
-        "display": "USPS Priority Mail Express® Legal Flat Rate Envelope"
-      },
-      {
-        "value": "USPS_PTP_EXP_PFRE",
-        "display": "USPS Priority Mail Express® Padded Flat Rate Envelope"
-      },
-      {
-        "value": "USPS_PTP_PRI_LFRE",
-        "display": "USPS Priority Mail® Legal Flat Rate Envelope"
-      },
-      {
-        "value": "USPS_PTP_PRI_PFRE",
-        "display": "USPS Priority Mail® Padded Flat Rate Envelope"
-      },
-      {
-        "value": "USPS_PTP_PRI_RA",
-        "display": "USPS Priority Mail Regional Rate® Box A"
-      },
-      {
-        "value": "USPS_PTP_PRI_RB",
-        "display": "USPS Priority Mail Regional Rate® Box B"
-      },
-      {
-        "value": "USPS_PTP_BPM",
-        "display": "USPS Bound Printed Matter"
-      },
-      {
         "value": "ONTRAC_MFN_GROUND",
         "display": "OnTrac MFN Ground"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ordoro/shipper-options",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "A collection of shipper options",
   "main": "ShipperOptions.json",
   "scripts": {


### PR DESCRIPTION
### Removed dup `Amazon` shipping methods

- I don't know how these got there and it wasn't important until we
  needed to literally list out these options that I noticed it.
- Anyway... gone.

ordoro/ordoro#9309

ordoro/shipper-options@c94155ebae750280d1a8f47a42f8538539b3a24d

___

### 1.5.3

ordoro/shipper-options@ea6f8315665dda705a726c665d4e02ceab5d1bc9