### PR TITLE
7554-DHL-Ecommerce-Return-Options => master

### DIFF
--- a/ShipperOptions.json
+++ b/ShipperOptions.json
@@ -657,19 +657,66 @@
       {"display": "Parcel", "value": "PKG"}
     ],
     "shipping_method": [
-      {"value": "EXP", "display": "Parcel Expedited"},
-      {"value": "MAX", "display": "Parcel Expedited Max"},
-      {"value": "GND", "display": "Parcel Ground"},
-      {"value": "BEX", "display": "BPM Expedited"},
-      {"value": "BGN", "display": "BPM Ground"},
-      {"value": "PLT", "display": "Parcel International Direct"},
-      {"value": "PLY", "display": "Parcel International Standard"},
-      {"value": "PKY", "display": "Packet International"},
-      {"value": "PIY", "display": "Parcel International Direct Priority"},
-      {"value": "PID", "display": "Parcel International Direct Standard"},
-      {"value": "RGN", "display": "DHL SmartMail Parcel Return Ground", "type": "return"},
-      {"value": "RPL", "display": "DHL SmartMail Parcel Return Plus", "type": "return"},
-      {"value": "RLT", "display": "DHL SmartMail Parcel Return Light", "type": "return"}
+      {
+        "value": "EXP",
+        "display": "Parcel Expedited"
+      },
+      {
+        "value": "MAX",
+        "display": "Parcel Expedited Max"
+      },
+      {
+        "value": "GND",
+        "display": "Parcel Ground"
+      },
+      {
+        "value": "BEX",
+        "display": "BPM Expedited",
+        "no_rates": true
+      },
+      {
+        "value": "BGN",
+        "display": "BPM Ground",
+        "no_rates": true
+      },
+      {
+        "value": "PLT",
+        "display": "Parcel International Direct"
+      },
+      {
+        "value": "PLY",
+        "display": "Parcel International Standard"
+      },
+      {
+        "value": "PKY",
+        "display": "Packet International"
+      },
+      {
+        "value": "PIY",
+        "display": "Parcel International Direct Priority"
+      },
+      {
+        "value": "PID",
+        "display": "Parcel International Direct Standard"
+      },
+      {
+        "value": "RGN",
+        "display": "DHL SmartMail Parcel Return Ground",
+        "type": "return",
+        "no_rates": true
+      },
+      {
+        "value": "RPL",
+        "display": "DHL SmartMail Parcel Return Plus",
+        "type": "return",
+        "no_rates": true
+      },
+      {
+        "value": "RLT",
+        "display": "DHL SmartMail Parcel Return Light",
+        "type": "return",
+        "no_rates": true
+      }
     ],
     "dangerous_goods": [
       {"value": "01", "display": "Lithium Contained"},

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@ordoro/shipper-options",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "lockfileVersion": 1
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@ordoro/shipper-options",
-  "version": "1.9.4",
+  "version": "1.9.5",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ordoro/shipper-options",
-  "version": "1.9.4",
+  "version": "1.9.5",
   "description": "A collection of shipper options",
   "main": "ShipperOptions.json",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ordoro/shipper-options",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "description": "A collection of shipper options",
   "main": "ShipperOptions.json",
   "scripts": {


### PR DESCRIPTION
### 1.9.4

ordoro/shipper-options@ff7411b449b08a6abf51e3587269b3f0d213b335

___

### Added `no_rates` concept to dhl shipping methods

- `no_rates` will allow us to display shipping methods that don't have
  rates in the mix of shipping methods that do have rates.
- This allows us to continue to exclude the shipping methods that are
  normally rated but are excluded for a given package for whatever reason

ordoro/ordoro#7554

ordoro/shipper-options@1db7a5706ec594c657bc1c6f28cf6ec9ee22730c

___

### 1.9.5

ordoro/shipper-options@1b55d217cbcc034ebbeb76c410d3c90624d9cc39