### PR TITLE
11748-UPS-No-Delivery-Confirmation => master

### DIFF
--- a/ShipperOptions.json
+++ b/ShipperOptions.json
@@ -1424,10 +1424,6 @@
         "value": "0"
       },
       {
-        "display": "Delivery Confirmation",
-        "value": "1"
-      },
-      {
         "display": "Signature Required",
         "value": "2"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@ordoro/shipper-options",
-  "version": "1.9.8",
+  "version": "1.9.9",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ordoro/shipper-options",
-  "version": "1.9.8",
+  "version": "1.9.9",
   "description": "A collection of shipper options",
   "main": "ShipperOptions.json",
   "scripts": {


### PR DESCRIPTION
### Remove No Signature Delivery Confirmation for UPS

- UPS does not support this option anymore
- So neither do we

ordoro/ordoro#11748

ordoro/shipper-options@5d8ec51e72fb1d4bc424403704f716933370fbd7

___

### 1.9.9

ordoro/shipper-options@c5b6ddfa204cac93de2ef560024d626f7d7ed5ef