### PR TITLE
11798-Newgistics-Rates => master

### DIFF
--- a/ShipperOptions.json
+++ b/ShipperOptions.json
@@ -2657,23 +2657,28 @@
     "shipping_method": [
       {
         "display": "Priority",
-        "value": "PM"
+        "value": "PM",
+        "no_rates": true
       },
       {
         "display": "Parcel Select",
-        "value": "PRCLSEL"
+        "value": "PRCLSEL",
+        "no_rates": true
       },
       {
         "display": "Parcel Select Lightweight",
-        "value": "PSLW"
+        "value": "PSLW",
+        "no_rates": true
       },
       {
         "display": "First Class",
-        "value": "FCM"
+        "value": "FCM",
+        "no_rates": true
       },
       {
         "display": "Bound Printed Matter",
-        "value": "BPM"
+        "value": "BPM",
+        "no_rates": true
       }
     ],
     "box_shape": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@ordoro/shipper-options",
-  "version": "1.9.9",
+  "version": "1.9.10",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ordoro/shipper-options",
-  "version": "1.9.9",
+  "version": "1.9.10",
   "description": "A collection of shipper options",
   "main": "ShipperOptions.json",
   "scripts": {


### PR DESCRIPTION
### Added `no_rates: true` to newgistics service methods

- We need to label them as `no_rates: true` to make it possible to
  display the shipping methods with a rate. God that sounds stupid.
- This designation only means that these shipping methods can display
  if no rate is provided for it. It will display as TBD.
- Previously, Newgistics only worked with local rates. Pappy is now
  expecting to get rates for newgistics.
- Did I clear that up?

ordoro/ordoro#11798

ordoro/shipper-options@2922a6c42e3a98d5bd3f3f3871a1c8fef77bb8f8

___

### 1.9.10

ordoro/shipper-options@62a71b21cfbe30bd774b7a516b42a065b78747af