### PR TITLE
11811-pitney-sig-with-restricted-delivery => master

### DIFF
--- a/ShipperOptions.json
+++ b/ShipperOptions.json
@@ -1882,6 +1882,10 @@
       {
         "display": "Adult Signature Restricted Delivery",
         "value": "ADSIGRD"
+      },
+      {
+        "display": "Signature with Restricted Delivery",
+        "value": "SigRD"
       }
     ],
     "reason_for_export": [


### PR DESCRIPTION
### add SigRD as a Delivery Confirmation

* Pitney now supports `Signature with Restricted Delivery` so add it
  as an option in Ordoro

ordoro/ordoro#11811

ordoro/shipper-options@5fd9a98178072724f943ac23f194a44c568b43eb