### PR TITLE
7890-pitney-flat-package => master

### DIFF
--- a/ShipperOptions.json
+++ b/ShipperOptions.json
@@ -1796,6 +1796,10 @@
       {
         "value": "RBB",
         "display": "Regional Rate Box B"
+      },
+      {
+        "value": "Flat",
+        "display": "Flat"
       }
     ],
     "shipping_method": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@ordoro/shipper-options",
-  "version": "1.9.12",
+  "version": "1.9.13",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ordoro/shipper-options",
-  "version": "1.9.12",
+  "version": "1.9.13",
   "description": "A collection of shipper options",
   "main": "ShipperOptions.json",
   "scripts": {


### PR DESCRIPTION
### add Flat as a package type

* Pitney now supports Flat packages so add as an option in Ordoro

ordoro/ordoro#7890
ordoro/ordoro#11810

ordoro/shipper-options@74a3aba0035cda3654b51dd4f11394da2ebdcff5