### PR TITLE
12218-Even-Moore-Box-Shape-Info => main

### DIFF
--- a/ShipperOptions.json
+++ b/ShipperOptions.json
@@ -1458,42 +1458,47 @@
       {
         "display": "UPS Letter",
         "value": "01",
-        "flat_rate": true
+        "weight": false,
+        "dim_count": 0
       },
       {
         "display": "Tube",
         "value": "03",
-        "flat_rate": true
+        "weight": false,
+        "dim_count": 0
       },
       {
         "display": "PAK",
         "value": "04",
-        "flat_rate": true
+        "weight": false,
+        "dim_count": 0
       },
       {
         "display": "Small Express Box",
         "value": "2a",
-        "flat_rate": true
+        "dim_count": 0
       },
       {
         "display": "Medium Express Box",
         "value": "2b",
-        "flat_rate": true
+        "dim_count": 0
       },
       {
         "display": "Large Express Box",
         "value": "2c",
-        "flat_rate": true
+        "dim_count": 0
       },
       {
         "display": "UPS 10 KG Box®",
         "value": "25",
-        "flat_rate": true
+        "weight": false,
+        "dim_count": 0
       },
       {
         "display": "UPS 25 KG Box®",
         "value": "24",
-        "flat_rate": true
+        "weight": false,
+        "dim_count": 0
       },
       {
         "display": "Flats",
@@ -1506,27 +1511,32 @@
       {
         "display": "Simple Rate Extra Small",
         "value": "XS",
-        "flat_rate": true
+        "weight": false,
+        "dim_count": 0
       },
       {
         "display": "Simple Rate Small",
         "value": "S",
-        "flat_rate": true
+        "weight": false,
+        "dim_count": 0
       },
       {
         "display": "Simple Rate Medium",
         "value": "M",
-        "flat_rate": true
+        "weight": false,
+        "dim_count": 0
       },
       {
         "display": "Simple Rate Large",
         "value": "L",
-        "flat_rate": true
+        "weight": false,
+        "dim_count": 0
       },
       {
         "display": "Simple Rate Extra Large",
         "value": "XL",
-        "flat_rate": true
+        "weight": false,
+        "dim_count": 0
       }
     ],
     "box_shape_mail_innovations": [
@@ -1791,17 +1801,20 @@
       {
         "value": "SFRB",
         "display": "Small Flat Rate Box",
-        "flat_rate": true
+        "weight": false,
+        "dim_count": 0
       },
       {
         "value": "FRB",
         "display": "Medium Flat Rate Box",
-        "flat_rate": true
+        "weight": false,
+        "dim_count": 0
       },
       {
         "value": "LFRB",
         "display": "Large Flat Rate Box",
-        "flat_rate": true
+        "weight": false,
+        "dim_count": 0
       },
       {
         "value": "PKG",
@@ -1821,17 +1834,20 @@
       {
         "value": "FRE",
         "display": "Flat Rate Envelope",
-        "flat_rate": true
+        "weight": false,
+        "dim_count": 0
       },
       {
         "value": "LGLFRENV",
         "display": "Flat Rate Legal Envelope",
-        "flat_rate": true
+        "weight": false,
+        "dim_count": 0
       },
       {
         "value": "PFRENV",
         "display": "Flat Rate Padded Envelope",
-        "flat_rate": true
+        "weight": false,
+        "dim_count": 0
       },
       {
         "value": "FLAT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@ordoro/shipper-options",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ordoro/shipper-options",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "description": "A collection of shipper options",
   "main": "ShipperOptions.json",
   "scripts": {


### PR DESCRIPTION
### Split `flat_rate` into weight and dim props

- Need to have box shapes that have fixed dimensions but variable
  weight, so having a simple `flat_rate` prop is too simple
- So `flat_rate: true` becomes `weight: false` and `dim_count: 0`
- This uses the existing `dim_count` prop
- This establishes `weight: value` prop so if we want to hard code a
  weight in the future, we can.

ordoro/ordoro#12218

ordoro/shipper-options@7d3ea342317125eee8e1bd78d2c9c283309770ad

___

### 1.14.1

ordoro/shipper-options@5880156a8c6f516aecf968874dc3fe9d7b3f8bef