### PR TITLE
12492-duping-newgs => main

### DIFF
--- a/ShipperOptions.json
+++ b/ShipperOptions.json
@@ -2760,18 +2760,8 @@
     ],
     "shipping_method": [
       {
-        "display": "Priority",
-        "value": "PM",
-        "no_rates": true
-      },
-      {
         "display": "Parcel Select",
         "value": "PRCLSEL",
-        "no_rates": true
-      },
-      {
-        "display": "Ground Advantage",
-        "value": "UGA",
         "no_rates": true
       },
       {
@@ -2780,8 +2770,112 @@
         "no_rates": true
       },
       {
-        "display": "First Class",
-        "value": "FCM",
+        "display": "Bound Printed Matter",
+        "value": "BPM",
+        "no_rates": true
+      }
+    ],
+    "box_shape": [
+      {"display": "Parcel", "value": "PKG"}
+    ],
+    "nondelivery": [
+      {
+        "value": "AddressServiceRequested",
+        "display": "Address Service Requested"
+      },
+      {
+        "value": "AddressServiceRequestedBPRS",
+        "display": "Address Service Requested (BPRS)"
+      },
+      {
+        "value": "ReturnServiceRequested",
+        "display": "Return Service Requested"
+      },
+      {
+        "value": "ReturnServiceRequestedBPRS",
+        "display": "Return Service Requested (BPRS)"
+      },
+      {
+        "value": "ChangeServiceRequested",
+        "display": "Change Service Requested"
+      },
+      {
+        "value": "ForwardingServiceRequested",
+        "display": "Forwarding Service Requested"
+      },
+      {
+        "value": "ElectronicServiceRequested",
+        "display": "Electronic Service Requested"
+      }
+    ],
+    "dangerous_goods": [
+      {
+        "value": "Explosives",
+        "display": "Explosives"
+      },
+      {
+        "value": "Gases",
+        "display": "Gases"
+      },
+      {
+        "value": "FlammableCombustibleLiquids",
+        "display": "Flammable Combustible Liquids"
+      },
+      {
+        "value": "FlammableSolids",
+        "display": "Flammable Solids"
+      },
+      {
+        "value": "OxidizingSubstancesOrganicPeroxides",
+        "display": "Oxidizing Substances Organic Peroxides"
+      },
+      {
+        "value": "ToxicSubstancesAndInfectiousSubstances",
+        "display": "Toxic Substances And Infectious Substances"
+      },
+      {
+        "value": "RadioactiveMaterial",
+        "display": "Radioactive Material"
+      },
+      {
+        "value": "Corrosives",
+        "display": "Corrosives"
+      },
+      {
+        "value": "ORMD",
+        "display": "ORM-D"
+      },
+      {
+        "value": "ConsumerCommodities",
+        "display": "Consumer Commodities"
+      },
+      {
+        "value": "MiscellaneousHazardousMaterial",
+        "display": "Miscellaneous Hazardous Material"
+      }
+    ]
+  },
+  "pb_standard": {
+    "display_name": "PB Standard",
+    "delivery_confirmation": [
+      {
+        "display": "Delivery Confirmation",
+        "value": "DelCon"
+      },
+      {
+        "display": "Signature Required",
+        "value": "Sig"
+      }
+    ],
+    "shipping_method": [
+      {
+        "display": "Parcel Select",
+        "value": "PRCLSEL",
+        "no_rates": true
+      },
+      {
+        "display": "Parcel Select Lightweight",
+        "value": "PSLW",
         "no_rates": true
       },
       {


### PR DESCRIPTION
### Duplicating pb standard and newgistics for upcoming deprecation

- This seemed like it might be better to have both options during transition
then remove newgistics in favor of the new naming. Let me know if not.
- Remove unused and unavailable options from pb standard based on updated
pitney service types
brought to light and remove UGA for ordoro/ordoro#12492

ordoro/shipper-options@d5ae1a2dd6906bf3725889bafc6e41bfee9fdc0c