### PR TITLE
12680-ups-moar-hazmats => main

### DIFF
--- a/ShipperOptions.json
+++ b/ShipperOptions.json
@@ -1848,6 +1848,66 @@
         "display": "Passenger Aircraft",
         "value": "Passenger Aircraft"
       }
+    ],
+    "hazmat_transport_category": [
+      {
+        "display": "0",
+        "value": "0"
+      },
+      {
+        "display": "1",
+        "value": "1"
+      },
+      {
+        "display": "2",
+        "value": "2"
+      },
+      {
+        "display": "3",
+        "value": "3"
+      },
+      {
+        "display": "4",
+        "value": "4"
+      }
+    ],
+    "hazmat_tunnel_restriction_code": [
+      {
+        "display": "(B)",
+        "value": "(B)"
+      },
+      {
+        "display": "(B/D)",
+        "value": "(B/D)"
+      },
+      {
+        "display": "(B/E)",
+        "value": "(B/E)"
+      },
+      {
+        "display": "(C)",
+        "value": "(C)"
+      },
+      {
+        "display": "(C/D)",
+        "value": "(C/D)"
+      },
+      {
+        "display": "(C/E)",
+        "value": "(C/E)"
+      },
+      {
+        "display": "(D)",
+        "value": "(D)"
+      },
+      {
+        "display": "(D/E)",
+        "value": "(D/E)"
+      },
+      {
+        "display": "(E)",
+        "value": "(E)"
+      }
     ]
   },
   "usps": {


### PR DESCRIPTION
### UPS Hazmat options for tunnel restriction code and transport category

- I wasn't sure about the names for these, the descriptions are missing in UPS docs,
 but the options are enumerated so I figured it could be helpful.
- We will need these to be selectable in the UI and they are required for ADR
 regulation set, which defines ground only EU to EU shipments
- Here is a link about tunnel restrictions https://support.mapandguide.com/intranet/2023/en/Content/glossary/GLO_tbc.htm
- Transport Category from some random UPS document found online
    A category that ranges from 0 to 4 in
    the ADR regulation set which indicates
    the amount of points assigned to a
    dangerous goods package to be in
    compliance with the fully regulated
    vehicle load exemption (ADR 1.1.3.6).
ordoro/ordoro#12680

ordoro/shipper-options@4ced6e037578e1fc68b442edf4ec9101762fdeb4