### PR TITLE
11899-pitney-intl => main

### DIFF
--- a/ShipperOptions.json
+++ b/ShipperOptions.json
@@ -1986,6 +1986,20 @@
         "max_oz": 13
       },
       {
+        "value": "LGENV",
+        "display": "Large Envelope",
+        "max_dims": [15, 12, 0.75],
+        "dim_count": 2,
+        "max_oz": 15
+      },
+      {
+        "value": "NMLETTER",
+        "display": "Nonmachinable Letter",
+        "max_dims": [0.25, 11.5, 6.125],
+        "dim_count": 2,
+        "max_oz": 3.5
+      },
+      {
         "value": "SOFTPACK",
         "display": "Softpack",
         "max_dims": [15, 12, 2],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@ordoro/shipper-options",
-  "version": "1.14.15",
+  "version": "1.14.16",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ordoro/shipper-options",
-  "version": "1.14.15",
+  "version": "1.14.16",
   "description": "A collection of shipper options",
   "main": "ShipperOptions.json",
   "scripts": {


### PR DESCRIPTION
### pitney: add box types

- LGENV is what we should have displayed for FLAT
- FLAT works for FCM though
- NMLETTER is a new fun type with dimensional restrictions
ordoro/ordoro#11899

ordoro/shipper-options@447ae9b845c033d3db129eff12b5c375893c4fdd