### PR TITLE
pitney-parity => main

### DIFF
--- a/ShipperOptions.json
+++ b/ShipperOptions.json
@@ -2303,6 +2303,18 @@
       {
         "display": "Signature Required",
         "value": "Sig"
+      },
+      {
+        "display": "Adult Signature Required",
+        "value": "ADSIG"
+      },
+      {
+        "display": "Adult Signature Restricted Delivery",
+        "value": "ADSIGRD"
+      },
+      {
+        "display": "Signature with Restricted Delivery",
+        "value": "SigRD"
       }
     ],
     "reason_for_export": [
@@ -2329,6 +2341,16 @@
       {
         "display": "Other",
         "value": "OTHER"
+      }
+    ],
+    "tax_id_type": [
+      {
+        "display": "VAT",
+        "value": "VAT_NUMBER"
+      },
+      {
+        "display": "IOSS",
+        "value": "IOSS_NUMBER"
       }
     ]
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@ordoro/shipper-options",
-  "version": "1.14.17",
+  "version": "1.14.18",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ordoro/shipper-options",
-  "version": "1.14.17",
+  "version": "1.14.18",
   "description": "A collection of shipper options",
   "main": "ShipperOptions.json",
   "scripts": {


### PR DESCRIPTION
### Update pitney_merchant values with pitney values

- These should be the same essentially, they use the same api
- For ACH migrations

ordoro/shipper-options@09df03e1f83a3031057ab624bbc6e0106868f567