### PR TITLE
12844-fedex-overnight-extra-hours-and-display => main

### DIFF
--- a/ShipperOptions.json
+++ b/ShipperOptions.json
@@ -1107,15 +1107,15 @@
         "value": "FEDEX_2_DAY_AM"
       },
       {
-        "display": "Standard Overnight",
+        "display": "FedEx Standard Overnight",
         "value": "STANDARD_OVERNIGHT"
       },
       {
-        "display": "Priority Overnight",
+        "display": "FedEx Priority Overnight",
         "value": "PRIORITY_OVERNIGHT"
       },
       {
-        "display": "First Overnight",
+        "display": "FedEx First Overnight",
         "value": "FIRST_OVERNIGHT"
       },
       {
@@ -1133,6 +1133,18 @@
       {
         "display": "International First",
         "value": "INTERNATIONAL_FIRST"
+      },
+      {
+        "display": "FedEx First Overnight Extra Hours™",
+        "value": "FEDEX_FIRST_OVERNIGHT_EXTRA_HOURS"
+      },
+      {
+        "display": "FedEx Priority Overnight Extra Hours™",
+        "value": "FEDEX_PRIORITY_OVERNIGHT_EXTRA_HOURS"
+      },
+      {
+        "display": "FedEx Standard Overnight Extra Hours™",
+        "value": "FEDEX_STANDARD_OVERNIGHT_EXTRA_HOURS"
       }
     ],
     "insurance": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@ordoro/shipper-options",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ordoro/shipper-options",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "description": "A collection of shipper options",
   "main": "ShipperOptions.json",
   "scripts": {


### PR DESCRIPTION
### FedEx: include overnight extra hours services

- Update to include FedEx in overnight offerings per fedex
ordoro/ordoro#12844

ordoro/shipper-options@df1b84878de2a259e58da78f5a61f054106779d5

___

### 1.16.2

ordoro/shipper-options@224aec3952d1eccd80ef79058f83589be5c19329