### PR TITLE
13275-PB-Standard-Reason-For-Export => main

### DIFF
--- a/ShipperOptions.json
+++ b/ShipperOptions.json
@@ -3025,6 +3025,36 @@
         "value": "MiscellaneousHazardousMaterial",
         "display": "Miscellaneous Hazardous Material"
       }
+    ],
+    "reason_for_export": [
+      {
+        "display": "Merchandise",
+        "value": "MERCHANDISE"
+      },
+      {
+        "display": "Documents",
+        "value": "DOCUMENTS"
+      },
+      {
+        "display": "Gift",
+        "value": "GIFT"
+      },
+      {
+        "display": "Returned Goods",
+        "value": "RETURNED_GOODS"
+      },
+      {
+        "display": "Commercial Sample",
+        "value": "COMMERCIAL_SAMPLE"
+      },
+      {
+        "display": "Dangerous Goods",
+        "value": "DANGEROUS_GOODS"
+      },
+      {
+        "display": "Other",
+        "value": "OTHER"
+      }
     ]
   },
   "pb_standard": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@ordoro/shipper-options",
-  "version": "1.16.3",
+  "version": "1.17.0",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ordoro/shipper-options",
-  "version": "1.16.3",
+  "version": "1.17.0",
   "description": "A collection of shipper options",
   "main": "ShipperOptions.json",
   "scripts": {


### PR DESCRIPTION
### Add Reason for Export for PB Standard

- Added it to both PB Standard and Newgistics sections because why not

ordoro/ordoro#13275

ordoro/shipper-options@2a12e03f510a5507df3f44b0e5dfb9734be16d08

___

### 1.17.0

ordoro/shipper-options@f59daea8cdff664fee0d0ddf7597a9d717d592db