### PR TITLE
13081-ups-tax-id-types => main

### DIFF
--- a/ShipperOptions.json
+++ b/ShipperOptions.json
@@ -2911,11 +2911,15 @@
       },
       {
         "value": "UPS_PTP_NEXT_DAY_AIR",
-        "display": "UPS® Next Day Air"
+        "display": "UPS® Next Day Air®"
+      },
+      {
+        "value": "UPS_PTP_NEXT_DAY_AIR_SAT",
+        "display": "UPS® Next Day Air® Saturday"
       },
       {
         "value": "UPS_PTP_NEXT_DAY_AIR_SAVER",
-        "display": "UPS® Next Day Air Saver"
+        "display": "UPS® Next Day Air Saver®"
       },
       {
         "value": "STAMPS_US_PM_SFRB",

--- a/ShipperOptions.json
+++ b/ShipperOptions.json
@@ -2038,6 +2038,11 @@
         "display": "(E)",
         "value": "(E)"
       }
+    ],
+    "tax_id_type": [
+      {"display": "DNS", "value": "DNS"},
+      {"display": "EIN", "value": "EIN"},
+      {"display": "FGN", "value": "FGN"}
     ]
   },
   "usps": {
@@ -2260,14 +2265,8 @@
       }
     ],
     "tax_id_type": [
-      {
-        "display": "VAT",
-        "value": "VAT_NUMBER"
-      },
-      {
-        "display": "IOSS",
-        "value": "IOSS_NUMBER"
-      }
+      {"display": "VAT", "value": "VAT_NUMBER"},
+      {"display": "IOSS", "value": "IOSS_NUMBER"}
     ]
   },
   "pitney_merchant": {
@@ -2482,14 +2481,8 @@
       }
     ],
     "tax_id_type": [
-      {
-        "display": "VAT",
-        "value": "VAT_NUMBER"
-      },
-      {
-        "display": "IOSS",
-        "value": "IOSS_NUMBER"
-      }
+      {"display": "VAT", "value": "VAT_NUMBER"},
+      {"display": "IOSS", "value": "IOSS_NUMBER"}
     ]
   },
   "pitney_presort": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@ordoro/shipper-options",
-  "version": "1.20.2",
+  "version": "1.20.3",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ordoro/shipper-options",
-  "version": "1.20.2",
+  "version": "1.20.3",
   "description": "A collection of shipper options",
   "main": "ShipperOptions.json",
   "scripts": {


### PR DESCRIPTION
### UPS: add tax id type

- from UPS docs
- reformatted a couple of tax ids for readability when i was looking at this
ordoro/ordoro#13081

ordoro/shipper-options@6b5ab3d50ad3c8ada608d117a9aacd91051f7547

___

### sneaking one in bc it came through ordoro/ordoro#13559

ordoro/shipper-options@e8899ea8f440e0c9b6a3564f0460103687788a46