### PR TITLE
13595-fedex-parcel-return-removal => main

### DIFF
--- a/ShipperOptions.json
+++ b/ShipperOptions.json
@@ -1030,10 +1030,6 @@
       {
         "display": "Presorted Standard",
         "value": "PRESORTED_STANDARD"
-      },
-      {
-        "display": "Parcel Return",
-        "value": "PARCEL_RETURN"
       }
     ],
     "box_shape": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@ordoro/shipper-options",
-  "version": "1.20.3",
+  "version": "1.20.4",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ordoro/shipper-options",
-  "version": "1.20.3",
+  "version": "1.20.4",
   "description": "A collection of shipper options",
   "main": "ShipperOptions.json",
   "scripts": {


### PR DESCRIPTION
### Remove fedex ground economy indicia

- We cannot support this at this time, and we don't really know how it works
ordoro/ordoro#13595

ordoro/shipper-options@652f9ddf4835c6ae768a401980f5ba70f547f164

___

### 1.20.4

ordoro/shipper-options@ebf05d2a7a560cfbed6a69292a2120f713434c30