### PR TITLE
fedex-package-branding => main

### DIFF
--- a/ShipperOptions.json
+++ b/ShipperOptions.json
@@ -1054,31 +1054,31 @@
         "value": "FEDEX_TUBE"
       },
       {
-        "display": "One Rate® Envelope",
+        "display": "FedEx® Envelope",
         "value": "ONE_RATE_ENVELOPE"
       },
       {
-        "display": "One Rate® Small Box",
+        "display": "FedEx® Small Box",
         "value": "ONE_RATE_SMALL_BOX"
       },
       {
-        "display": "One Rate® Medium Box",
+        "display": "FedEx® Medium Box",
         "value": "ONE_RATE_MEDIUM_BOX"
       },
       {
-        "display": "One Rate® Large Box",
+        "display": "FedEx® Large Box",
         "value": "ONE_RATE_LARGE_BOX"
       },
       {
-        "display": "One Rate® Extra Large Box",
+        "display": "FedEx® Extra Large Box",
         "value": "ONE_RATE_EXTRA_LARGE_BOX"
       },
       {
-        "display": "One Rate® Pak",
+        "display": "FedEx® One Rate® Pak",
         "value": "ONE_RATE_PAK"
       },
       {
-        "display": "One Rate® Tube",
+        "display": "FedEx® One Rate® Tube",
         "value": "ONE_RATE_TUBE"
       }
     ],

--- a/ShipperOptions.json
+++ b/ShipperOptions.json
@@ -1038,47 +1038,47 @@
         "value": "YOUR_PACKAGING"
       },
       {
-        "display": "FedEx Box",
+        "display": "FedEx® Box",
         "value": "FEDEX_BOX"
       },
       {
-        "display": "FedEx Envelope",
+        "display": "FedEx® Envelope",
         "value": "FEDEX_ENVELOPE"
       },
       {
-        "display": "FedEx Pak",
+        "display": "FedEx® Pak",
         "value": "FEDEX_PAK"
       },
       {
-        "display": "FedEx Tube",
+        "display": "FedEx® Tube",
         "value": "FEDEX_TUBE"
       },
       {
-        "display": "One Rate Envelope",
+        "display": "One Rate® Envelope",
         "value": "ONE_RATE_ENVELOPE"
       },
       {
-        "display": "One Rate Small Box",
+        "display": "One Rate® Small Box",
         "value": "ONE_RATE_SMALL_BOX"
       },
       {
-        "display": "One Rate Medium Box",
+        "display": "One Rate® Medium Box",
         "value": "ONE_RATE_MEDIUM_BOX"
       },
       {
-        "display": "One Rate Large Box",
+        "display": "One Rate® Large Box",
         "value": "ONE_RATE_LARGE_BOX"
       },
       {
-        "display": "One Rate Extra Large Box",
+        "display": "One Rate® Extra Large Box",
         "value": "ONE_RATE_EXTRA_LARGE_BOX"
       },
       {
-        "display": "One Rate Pak",
+        "display": "One Rate® Pak",
         "value": "ONE_RATE_PAK"
       },
       {
-        "display": "One Rate Tube",
+        "display": "One Rate® Tube",
         "value": "ONE_RATE_TUBE"
       }
     ],

--- a/ShipperOptions.json
+++ b/ShipperOptions.json
@@ -1143,7 +1143,7 @@
         "value": "FEDEX_INTERNATIONAL_PRIORITY_EXPRESS"
       },
       {
-        "display": "FedEx International Connect Plus™",
+        "display": "FedEx® International Connect Plus",
         "value": "FEDEX_INTERNATIONAL_CONNECT_PLUS"
       },
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@ordoro/shipper-options",
-  "version": "1.20.4",
+  "version": "1.20.5",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ordoro/shipper-options",
-  "version": "1.20.4",
+  "version": "1.20.5",
   "description": "A collection of shipper options",
   "main": "ShipperOptions.json",
   "scripts": {


### PR DESCRIPTION
### FedEx packages need special names

ordoro/shipper-options@7e2bbd838a08996b45141d875e3a8d6e54f88d9b

___

### 1.20.5

ordoro/shipper-options@8e44a532b451f2a2ef63f0b42ddafc25faeed681

___

### update one rate packages, but we may have dupes, good enough for now

ordoro/shipper-options@55c3a1afbc4f434d4c4b48bc793943aa52abd220

___

### update fedex international connect plus name

- i guess they already changed it from when we added it last month

ordoro/shipper-options@7c4d639ba8f953fdc3db4a59380d877bd4b23015