### PR TITLE
13864-amazon-fedex-ground-economy-smart-post => main

### DIFF
--- a/ShipperOptions.json
+++ b/ShipperOptions.json
@@ -2601,7 +2601,7 @@
     ]
   },
   "amazon": {
-    "display_name": "Amazon SFP",
+    "display_name": "Amazon Buy Shipping",
     "dimensions_required": true,
     "customs_form": [],
     "contents_type": [],
@@ -2856,6 +2856,10 @@
       {
         "value": "FEDEX_PTP_EXPRESS_SAVER_ONE_RATE",
         "display": "FedEx® Express Saver® One Rate®"
+      },
+      {
+        "value": "FEDEX_PTP_SMARTPOST",
+        "display": "FedEx Ground® Economy"
       },
       {
         "value": "USPS_PTP_EXP",


### PR DESCRIPTION
### Add shipper option for fedex for amazon shipping

- use fedex naming even though it says smartpost
ordoro/ordoro#13864

ordoro/shipper-options@341a3cfe534afa312d39e747653a725ff437734b