### PR TITLE
14013-One-Rate-Options => main

### DIFF
--- a/ShipperOptions.json
+++ b/ShipperOptions.json
@@ -1049,7 +1049,8 @@
       {
         "display": "FedEx® Box",
         "value": "FEDEX_BOX",
-        "dimensions_required": true
+        "dimensions_required": true,
+        "hide_for_one_rate": true
       },
       {
         "display": "FedEx® Envelope",
@@ -1065,15 +1066,21 @@
       },
       {
         "display": "FedEx One Rate® - FedEx® Envelope",
-        "value": "ONE_RATE_ENVELOPE"
+        "value": "ONE_RATE_ENVELOPE",
+        "temp_use_fedex_auth": "comment property to make chopping easier",
+        "hide_for_csp": true
       },
       {
         "display": "FedEx One Rate® - FedEx® Pak",
-        "value": "ONE_RATE_PAK"
+        "value": "ONE_RATE_PAK",
+        "temp_use_fedex_auth": "comment property to make chopping easier",
+        "hide_for_csp": true
       },
       {
         "display": "FedEx One Rate® - FedEx® Tube",
-        "value": "ONE_RATE_TUBE"
+        "value": "ONE_RATE_TUBE",
+        "temp_use_fedex_auth": "comment property to make chopping easier",
+        "hide_for_csp": true
       },
       {
         "display": "FedEx® Small Box",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@ordoro/shipper-options",
-  "version": "1.20.15",
+  "version": "1.21.0",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ordoro/shipper-options",
-  "version": "1.20.15",
+  "version": "1.21.0",
   "description": "A collection of shipper options",
   "main": "ShipperOptions.json",
   "scripts": {


### PR DESCRIPTION
### Hide box option for one rate

- One Rate can't use box option
- Also hide the "One Rate" box shapes that are duplicates of the
  existing options, but only if using CSP

ordoro/ordoro#14013

ordoro/shipper-options@9e74fcd5d523ab4cacbebcc75d9de3098f882886