### PR TITLE
13124-remove-gcr-refs => main

### DIFF
--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -18,13 +18,14 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [17.2.0]
+        node-version: [20.11.0]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
+      - run: npm ci
       - run: npm test

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -1,0 +1,30 @@
+# This workflow will do a clean install of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Tests
+
+on:
+  push:
+    branches:
+      - '**'
+    paths-ignore:
+      - version.json
+    tags-ignore:
+      - v[0-9]+.[0-9]+.[0-9]+
+
+jobs:
+  run_test_suite:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [17.2.0]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+      - run: npm test

--- a/Dockerfile-build-package
+++ b/Dockerfile-build-package
@@ -1,4 +1,4 @@
-FROM gcr.io/ordoro-dev/python-build-package:latest
+FROM us-west1-docker.pkg.dev/ordoro-infra-ops/ordoro-services/python-build-package:latest
 
 COPY shipper_options /app/shipper_options
 COPY setup.py /app/setup.py

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,8 +1,0 @@
-steps:
-- id: Build Docker Image
-  name: 'gcr.io/cloud-builders/docker'
-  args: ["build", "-t", "gcr.io/ordoro-dev/shipper-options:test", "--file", "Dockerfile", "."]
-
-- id: Run Tests
-  name: 'gcr.io/cloud-builders/docker'
-  args: ['run', '--tty', 'gcr.io/$PROJECT_ID/$REPO_NAME:test', 'npm', 'test']


### PR DESCRIPTION
### remove gcr references and cloudbuild

- move test to github actions, we don't really use cloudbuild anymore
- ordoro/ordoro#13124

ordoro/shipper-options@3b31b257d84c2e261d285757fd0834d504c74d72