### PR TITLE
rfc-deprecated-shippers => main

### DIFF
--- a/ShipperOptions.json
+++ b/ShipperOptions.json
@@ -223,6 +223,7 @@
     ]
   },
   "pitney_cbds": {
+    "deprecated": true,
     "display_name": "USPS (CBDS)",
     "dimensions_required": true,
     "box_shape": [
@@ -812,6 +813,7 @@
     ]
   },
   "endicia": {
+    "deprecated": true,
     "customs_form": [
       {
         "display": "None",
@@ -3550,6 +3552,7 @@
     ]
   },
   "newgistics": {
+    "deprecated": true,
     "display_name": "PB Standard",
     "dimensions_required": true,
     "delivery_confirmation": [
@@ -3800,6 +3803,7 @@
     ]
   },
   "visible_usps": {
+    "deprecated": true,
     "display_name": "USPS",
     "box_shape": [
       {
@@ -3944,6 +3948,7 @@
     ]
   },
   "onelivex": {
+    "deprecated": true,
     "display_name": "X Delivery",
     "dimensions_required": true,
     "box_shape": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@ordoro/shipper-options",
-  "version": "1.21.7",
+  "version": "1.21.8",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ordoro/shipper-options",
-  "version": "1.21.7",
+  "version": "1.21.8",
   "description": "A collection of shipper options",
   "main": "ShipperOptions.json",
   "scripts": {


### PR DESCRIPTION
### add deprecated key to shippers

- i don't know if we can delete these outright just yet if there are lingering labels that had mapped services
- RFC: should i just delete them, or is this good for use in other areas?
- namely, the api label_info does box shape conversions by just grabbing the top level shipper keys here and that doesn't seem necessary if the shipper is no longer viable
- related to ordoro/ordoro#13346

ordoro/shipper-options@cbb4cf458c979ca8cee7020fb4f75e7987ccbc5f

___

### 1.21.8

ordoro/shipper-options@354c2199fab897391b73fb03446ce007d9b0023d