### PR TITLE
13990-dimensions-required => main

### DIFF
--- a/ShipperOptions.json
+++ b/ShipperOptions.json
@@ -2114,97 +2114,97 @@
       {
         "display": "3-Digit",
         "value": "3D",
-        "dimensions_required": true,
+        "dimensions_required": true
       },
       {
         "display": "3-Digit Dimensional Rectangular",
         "value": "3N",
-        "dimensions_required": true,
+        "dimensions_required": true
       },
       {
         "display": "3-Digit Dimensional Nonrectangular",
         "value": "3R",
-        "dimensions_required": true,
+        "dimensions_required": true
       },
       {
         "display": "5-Digit",
         "value": "5D",
-        "dimensions_required": true,
+        "dimensions_required": true
       },
       {
         "display": "Basic",
         "value": "BA",
-        "dimensions_required": true,
+        "dimensions_required": true
       },
       {
         "display": "Mixed NDC",
         "value": "BB",
-        "dimensions_required": true,
+        "dimensions_required": true
       },
       {
         "display": "NDC",
         "value": "BM",
-        "dimensions_required": true,
+        "dimensions_required": true
       },
       {
         "display": "Cubic Pricing Tier 1",
         "value": "C1",
-        "dimensions_required": true,
+        "dimensions_required": true
       },
       {
         "display": "Cubic Pricing Tier 2",
         "value": "C2",
-        "dimensions_required": true,
+        "dimensions_required": true
       },
       {
         "display": "Cubic Pricing Tier 3",
         "value": "C3",
-        "dimensions_required": true,
+        "dimensions_required": true
       },
       {
         "display": "Cubic Pricing Tier 4",
         "value": "C4",
-        "dimensions_required": true,
+        "dimensions_required": true
       },
       {
         "display": "Cubic Pricing Tier 5",
         "value": "C5",
-        "dimensions_required": true,
+        "dimensions_required": true
       },
       {
         "display": "Cubic Parcel",
         "value": "CP",
-        "dimensions_required": true,
+        "dimensions_required": true
       },
       {
         "display": "USPS Connect Local® Mail",
         "value": "CM",
-        "dimensions_required": true,
+        "dimensions_required": true
       },
       {
         "display": "NDC",
         "value": "DC",
-        "dimensions_required": true,
+        "dimensions_required": true
       },
       {
         "display": "SCF",
         "value": "DE",
-        "dimensions_required": true,
+        "dimensions_required": true
       },
       {
         "display": "5-Digit",
         "value": "DF",
-        "dimensions_required": true,
+        "dimensions_required": true
       },
       {
         "display": "Dimensional Nonrectangular",
         "value": "DN",
-        "dimensions_required": true,
+        "dimensions_required": true
       },
       {
         "display": "Dimensional Rectangular",
         "value": "DR",
-        "dimensions_required": true,
+        "dimensions_required": true
       },
       {
         "display": "Priority Mail Express Flat Rate Envelope <fix> Post Office To Addressee",
@@ -2241,7 +2241,7 @@
       {
         "display": "USPS Connect® Local Single Piece",
         "value": "LC",
-        "dimensions_required": true,
+        "dimensions_required": true
       },
       {
         "display": "USPS Connect® Local Flat Rate Box",
@@ -2254,7 +2254,7 @@
       {
         "display": "USPS Connect® Local Oversized",
         "value": "LO",
-        "dimensions_required": true,
+        "dimensions_required": true
       },
       {
         "display": "USPS Connect® Local Small Flat Rate Bag",
@@ -2263,102 +2263,102 @@
       {
         "display": "Non-Presorted",
         "value": "NP",
-        "dimensions_required": true,
+        "dimensions_required": true
       },
       {
         "display": "Full Tray Box",
         "value": "O1",
-        "dimensions_required": true,
+        "dimensions_required": true
       },
       {
         "display": "Half Tray Box",
         "value": "O2",
-        "dimensions_required": true,
+        "dimensions_required": true
       },
       {
         "display": "EMM Tray Box",
         "value": "O3",
-        "dimensions_required": true,
+        "dimensions_required": true
       },
       {
         "display": "Flat Tub Tray Box",
         "value": "O4",
-        "dimensions_required": true,
+        "dimensions_required": true
       },
       {
         "display": "Surface Transported Pallet",
         "value": "O5",
-        "dimensions_required": true,
+        "dimensions_required": true
       },
       {
         "display": "Full Pallet Box",
         "value": "O6",
-        "dimensions_required": true,
+        "dimensions_required": true
       },
       {
         "display": "Half Pallet Box",
         "value": "O7",
-        "dimensions_required": true,
+        "dimensions_required": true
       },
       {
         "display": "Oversized",
         "value": "OS",
-        "dimensions_required": true,
+        "dimensions_required": true
       },
       {
         "display": "Cubic Soft Pack Tier 1",
         "value": "P5",
-        "dimensions_required": true,
+        "dimensions_required": true
       },
       {
         "display": "Cubic Soft Pack Tier 2",
         "value": "P6",
-        "dimensions_required": true,
+        "dimensions_required": true
       },
       {
         "display": "Cubic Soft Pack Tier 3",
         "value": "P7",
-        "dimensions_required": true,
+        "dimensions_required": true
       },
       {
         "display": "Cubic Soft Pack Tier 4",
         "value": "P8",
-        "dimensions_required": true,
+        "dimensions_required": true
       },
       {
         "display": "Cubic Soft Pack Tier 5",
         "value": "P9",
-        "dimensions_required": true,
+        "dimensions_required": true
       },
       {
         "display": "Cubic Soft Pack Tier 6",
         "value": "Q6",
-        "dimensions_required": true,
+        "dimensions_required": true
       },
       {
         "display": "Cubic Soft Pack Tier 7",
         "value": "Q7",
-        "dimensions_required": true,
+        "dimensions_required": true
       },
       {
         "display": "Cubic Soft Pack Tier 8",
         "value": "Q8",
-        "dimensions_required": true,
+        "dimensions_required": true
       },
       {
         "display": "Cubic Soft Pack Tier 9",
         "value": "Q9",
-        "dimensions_required": true,
+        "dimensions_required": true
       },
       {
         "display": "Cubic Soft Pack Tier 10",
         "value": "Q0",
-        "dimensions_required": true,
+        "dimensions_required": true
       },
       {
         "display": "Priority Mail Express Single Piece",
         "value": "PA",
-        "dimensions_required": true,
+        "dimensions_required": true
       },
       {
         "display": "Large Flat Rate Box",
@@ -2371,7 +2371,7 @@
       {
         "display": "Presorted",
         "value": "PR",
-        "dimensions_required": true,
+        "dimensions_required": true
       },
       {
         "display": "Small Flat Rate Bag",
@@ -2380,17 +2380,17 @@
       {
         "display": "SCF Dimensional Nonrectangular",
         "value": "SN",
-        "dimensions_required": true,
+        "dimensions_required": true
       },
       {
         "display": "Single Piece",
         "value": "SP",
-        "dimensions_required": true,
+        "dimensions_required": true
       },
       {
         "display": "SCF Dimensional Rectangular",
         "value": "SR",
-        "dimensions_required": true,
+        "dimensions_required": true
       }
     ],
     "shipping_method": [

--- a/ShipperOptions.json
+++ b/ShipperOptions.json
@@ -2107,86 +2107,104 @@
   },
   "usps_ship": {
     "display_name": "USPS",
-    "dimensions_required": true,
     "customs_form": [],
     "contents_type": [],
     "insurance": [],
     "box_shape": [
       {
         "display": "3-Digit",
-        "value": "3D"
+        "value": "3D",
+        "dimensions_required": true,
       },
       {
         "display": "3-Digit Dimensional Rectangular",
-        "value": "3N"
+        "value": "3N",
+        "dimensions_required": true,
       },
       {
         "display": "3-Digit Dimensional Nonrectangular",
-        "value": "3R"
+        "value": "3R",
+        "dimensions_required": true,
       },
       {
         "display": "5-Digit",
-        "value": "5D"
+        "value": "5D",
+        "dimensions_required": true,
       },
       {
         "display": "Basic",
-        "value": "BA"
+        "value": "BA",
+        "dimensions_required": true,
       },
       {
         "display": "Mixed NDC",
-        "value": "BB"
+        "value": "BB",
+        "dimensions_required": true,
       },
       {
         "display": "NDC",
-        "value": "BM"
+        "value": "BM",
+        "dimensions_required": true,
       },
       {
         "display": "Cubic Pricing Tier 1",
-        "value": "C1"
+        "value": "C1",
+        "dimensions_required": true,
       },
       {
         "display": "Cubic Pricing Tier 2",
-        "value": "C2"
+        "value": "C2",
+        "dimensions_required": true,
       },
       {
         "display": "Cubic Pricing Tier 3",
-        "value": "C3"
+        "value": "C3",
+        "dimensions_required": true,
       },
       {
         "display": "Cubic Pricing Tier 4",
-        "value": "C4"
+        "value": "C4",
+        "dimensions_required": true,
       },
       {
         "display": "Cubic Pricing Tier 5",
-        "value": "C5"
+        "value": "C5",
+        "dimensions_required": true,
       },
       {
         "display": "Cubic Parcel",
-        "value": "CP"
+        "value": "CP",
+        "dimensions_required": true,
       },
       {
         "display": "USPS Connect Local® Mail",
-        "value": "CM"
+        "value": "CM",
+        "dimensions_required": true,
       },
       {
         "display": "NDC",
-        "value": "DC"
+        "value": "DC",
+        "dimensions_required": true,
       },
       {
         "display": "SCF",
-        "value": "DE"
+        "value": "DE",
+        "dimensions_required": true,
       },
       {
         "display": "5-Digit",
-        "value": "DF"
+        "value": "DF",
+        "dimensions_required": true,
       },
       {
         "display": "Dimensional Nonrectangular",
-        "value": "DN"
+        "value": "DN",
+        "dimensions_required": true,
       },
       {
         "display": "Dimensional Rectangular",
-        "value": "DR"
+        "value": "DR",
+        "dimensions_required": true,
       },
       {
         "display": "Priority Mail Express Flat Rate Envelope <fix> Post Office To Addressee",
@@ -2222,7 +2240,8 @@
       },
       {
         "display": "USPS Connect® Local Single Piece",
-        "value": "LC"
+        "value": "LC",
+        "dimensions_required": true,
       },
       {
         "display": "USPS Connect® Local Flat Rate Box",
@@ -2234,7 +2253,8 @@
       },
       {
         "display": "USPS Connect® Local Oversized",
-        "value": "LO"
+        "value": "LO",
+        "dimensions_required": true,
       },
       {
         "display": "USPS Connect® Local Small Flat Rate Bag",
@@ -2242,83 +2262,103 @@
       },
       {
         "display": "Non-Presorted",
-        "value": "NP"
+        "value": "NP",
+        "dimensions_required": true,
       },
       {
         "display": "Full Tray Box",
-        "value": "O1"
+        "value": "O1",
+        "dimensions_required": true,
       },
       {
         "display": "Half Tray Box",
-        "value": "O2"
+        "value": "O2",
+        "dimensions_required": true,
       },
       {
         "display": "EMM Tray Box",
-        "value": "O3"
+        "value": "O3",
+        "dimensions_required": true,
       },
       {
         "display": "Flat Tub Tray Box",
-        "value": "O4"
+        "value": "O4",
+        "dimensions_required": true,
       },
       {
         "display": "Surface Transported Pallet",
-        "value": "O5"
+        "value": "O5",
+        "dimensions_required": true,
       },
       {
         "display": "Full Pallet Box",
-        "value": "O6"
+        "value": "O6",
+        "dimensions_required": true,
       },
       {
         "display": "Half Pallet Box",
-        "value": "O7"
+        "value": "O7",
+        "dimensions_required": true,
       },
       {
         "display": "Oversized",
-        "value": "OS"
+        "value": "OS",
+        "dimensions_required": true,
       },
       {
         "display": "Cubic Soft Pack Tier 1",
-        "value": "P5"
+        "value": "P5",
+        "dimensions_required": true,
       },
       {
         "display": "Cubic Soft Pack Tier 2",
-        "value": "P6"
+        "value": "P6",
+        "dimensions_required": true,
       },
       {
         "display": "Cubic Soft Pack Tier 3",
-        "value": "P7"
+        "value": "P7",
+        "dimensions_required": true,
       },
       {
         "display": "Cubic Soft Pack Tier 4",
-        "value": "P8"
+        "value": "P8",
+        "dimensions_required": true,
       },
       {
         "display": "Cubic Soft Pack Tier 5",
-        "value": "P9"
+        "value": "P9",
+        "dimensions_required": true,
       },
       {
         "display": "Cubic Soft Pack Tier 6",
-        "value": "Q6"
+        "value": "Q6",
+        "dimensions_required": true,
       },
       {
         "display": "Cubic Soft Pack Tier 7",
-        "value": "Q7"
+        "value": "Q7",
+        "dimensions_required": true,
       },
       {
         "display": "Cubic Soft Pack Tier 8",
-        "value": "Q8"
+        "value": "Q8",
+        "dimensions_required": true,
       },
       {
         "display": "Cubic Soft Pack Tier 9",
-        "value": "Q9"
+        "value": "Q9",
+        "dimensions_required": true,
       },
       {
         "display": "Cubic Soft Pack Tier 10",
-        "value": "Q0"
+        "value": "Q0",
+        "dimensions_required": true,
       },
       {
         "display": "Priority Mail Express Single Piece",
-        "value": "PA"
+        "value": "PA",
+        "dimensions_required": true,
       },
       {
         "display": "Large Flat Rate Box",
@@ -2330,7 +2370,8 @@
       },
       {
         "display": "Presorted",
-        "value": "PR"
+        "value": "PR",
+        "dimensions_required": true,
       },
       {
         "display": "Small Flat Rate Bag",
@@ -2338,15 +2379,18 @@
       },
       {
         "display": "SCF Dimensional Nonrectangular",
-        "value": "SN"
+        "value": "SN",
+        "dimensions_required": true,
       },
       {
         "display": "Single Piece",
-        "value": "SP"
+        "value": "SP",
+        "dimensions_required": true,
       },
       {
         "display": "SCF Dimensional Rectangular",
-        "value": "SR"
+        "value": "SR",
+        "dimensions_required": true,
       }
     ],
     "shipping_method": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@ordoro/shipper-options",
-  "version": "1.21.12",
+  "version": "1.21.13",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ordoro/shipper-options",
-  "version": "1.21.12",
+  "version": "1.21.13",
   "description": "A collection of shipper options",
   "main": "ShipperOptions.json",
   "scripts": {


### PR DESCRIPTION
### Don't require dimensions for flat rate
- If we send dimensions for a box shape and those dimensions don't fit within a flat rate box then that box type is ignored
- Support doesn't like, they would like flat rates to always return if that's the box type selected regardless of the input dimensions
- So, send 0x0x0 for these box types
- I'm completely guessing which of these matter based on the word 'flat'
ordoro/ordoro#13990

ordoro/shipper-options@d7dda8c17bc93fdfbdd4d369c61cb36db48843af