### PR TITLE
14938-rate-label-options => main

### DIFF
--- a/Dockerfile-build-package
+++ b/Dockerfile-build-package
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 us-west1-docker.pkg.dev/ordoro-infra-ops/ordoro-services/python-build-package:latest
+FROM us-west1-docker.pkg.dev/ordoro-infra-ops/ordoro-services/python-build-package:latest
 
 COPY shipper_options /app/shipper_options
 COPY setup.py /app/setup.py

--- a/ShipperOptions.json
+++ b/ShipperOptions.json
@@ -289,6 +289,37 @@
         "display": "Parcels"
       }
     ],
+    "label_options": [
+      "customer_logo",
+      "customs",
+      "duty_payment_account",
+      "duty_payment_type",
+      "federal_tax_id",
+      "foreign_trade_regulation",
+      "insured_value",
+      "internal_transaction_number",
+      "is_dutiable",
+      "nonstandard_contents",
+      "nonstandard_day",
+      "pickup",
+      "ship_date",
+      "shipper_currency",
+      "shipping_payment_account",
+      "shipping_payment_type",
+      "signature_service",
+      "state_tax_id"
+    ],
+    "rate_options": [
+      "insured_value",
+      "is_dutiable",
+      "nonstandard_contents",
+      "nonstandard_day",
+      "pickup",
+      "service_type",
+      "ship_date",
+      "shipper_currency",
+      "signature_service"
+    ]
     "shipping_method": [
       {
         "value": "0",
@@ -684,6 +715,9 @@
     "box_shape": [
       {"display": "Parcel", "value": "PKG"}
     ],
+    "label_options": ["ship_date", "delivery_confirmation", "shipper_currency", "insured_value", "customs", "dangerous_goods", "service_endorsement"],
+    "rate_options": ["service_type", "ship_date", "delivery_confirmation", "shipper_currency", "insured_value", "customs", "dangerous_goods"],
+    "return_label_options": ["order_number", "return_reason"],
     "shipping_method": [
       {
         "value": "EXP",

--- a/ShipperOptions.json
+++ b/ShipperOptions.json
@@ -2609,6 +2609,30 @@
         "dimensions_required": true
       }
     ],
+    "label_options": [
+      "alternate_return_to_address",
+      "customs",
+      "delivery_confirmation",
+      "has_nonstandard_characteristics",
+      "hazmat_type",
+      "ignore_bad_address",
+      "mailing_zip_code",
+      "non_delivery",
+      "processing_category",
+      "rate_indicator",
+      "reference_number",
+      "ship_date"
+    ],
+    "rate_options": [
+      "delivery_confirmation",
+      "has_nonstandard_characteristics",
+      "hazmat_type",
+      "mailing_zip_code",
+      "processing_category",
+      "rate_holder_eps",
+      "service_type",
+      "ship_date"
+    ],
     "shipping_method": [
       {
         "display": "Parcel Select",

--- a/ShipperOptions.json
+++ b/ShipperOptions.json
@@ -4399,6 +4399,8 @@
         "display": "Custom Packaging"
       }
     ],
+    "label_options": ["service_token", "shipment_id"],
+    "rate_options": ["amazon_order_id", "order_items", "ship_date"],
     "shipping_method": [
       {
         "value": "std-us-swa-mfn",

--- a/ShipperOptions.json
+++ b/ShipperOptions.json
@@ -3672,6 +3672,7 @@
         "display": "Large Envelope"
       }
     ],
+    "label_options": ["non_delivery", "delivery_confirmation", "reference_number", "mailing_zip_code"],
     "shipping_method": [
       {
         "value": "STANDARD",

--- a/ShipperOptions.json
+++ b/ShipperOptions.json
@@ -94,6 +94,8 @@
         "dimensions_required": true
       }
     ],
+    "rate_options": ["service_option", "ship_date", "delivery_confirmation"],
+    "label_options": ["nondelivery_option", "service_option", "delivery_confirmation", "assigned_to_group_id"],
     "shipping_method": [
       {
         "display": "Regular Parcel",

--- a/ShipperOptions.json
+++ b/ShipperOptions.json
@@ -2970,6 +2970,44 @@
         "dimensions_required": true
       }
     ],
+    "label_options": [
+      "postal_reporting_number",
+      "pb_shipper_id",
+      "ship_date",
+      "non_delivery",
+      "delivery_confirmation",
+      "reference_number",
+      "mailing_zip_code",
+      "sender_signature",
+      "rate_type",
+      "international_rate_type",
+      "integrator_id",
+      "international_integrator_id",
+      "nsa_type",
+      "alternate_return_to_address",
+      "hazmat_type",
+      "hazmat_electronics",
+      "parcel_characteristics"
+    ]
+    "rate_options": [
+      "service_type",
+      "postal_reporting_number",
+      "pb_shipper_id",
+      "ship_date",
+      "non_delivery",
+      "delivery_confirmation",
+      "reference_number",
+      "mailing_zip_code",
+      "rate_type",
+      "international_rate_type",
+      "integrator_id",
+      "international_integrator_id",
+      "published_rates",
+      "nsa_type",
+      "hazmat_type",
+      "hazmat_electronics",
+      "parcel_characteristics"
+    ],
     "shipping_method": [
       {
         "value": "FCM",

--- a/ShipperOptions.json
+++ b/ShipperOptions.json
@@ -3840,6 +3840,28 @@
         "value": "discounted_insurance"
       }
     ],
+    "label_options": [
+      "alcohol_shipment_license",
+      "alternate_return_to_address",
+      "batteries",
+      "customs",
+      "delivery_confirmation",
+      "duties_payment_account",
+      "duties_payment_type",
+      "email_alert",
+      "etd_service_default_false",
+      "evening_delivery",
+      "hold_at_location_id",
+      "importer_of_record_account_number",
+      "importer_of_record_address",
+      "importer_of_record_tin",
+      "is_return",
+      "payment_account",
+      "payment_type",
+      "priority_alert",
+      "saturday_delivery",
+      "ship_date"
+    ],
     "payor": [
       {
         "display": "Sender",
@@ -3857,6 +3879,29 @@
     "priority_alert": [
       {"value": "PRIORITY_ALERT", "display": "Priority Alert"},
       {"value": "PRIORITY_ALERT_PLUS", "display": "Priority Alert Plus"}
+    ],
+    "rate_options": [
+      "alcohol_shipment_license",
+      "alternate_return_to_address",
+      "batteries",
+      "customs",
+      "delivery_confirmation",
+      "duties_payment_account",
+      "duties_payment_type",
+      "email_alert",
+      "etd_service_default_false",
+      "evening_delivery",
+      "hold_at_location_id",
+      "importer_of_record_account_number",
+      "importer_of_record_address",
+      "importer_of_record_tin",
+      "is_return",
+      "payment_account",
+      "payment_type",
+      "priority_alert",
+      "saturday_delivery",
+      "service_type",
+      "ship_date"
     ],
     "reason_for_export": [
       {

--- a/ShipperOptions.json
+++ b/ShipperOptions.json
@@ -1914,6 +1914,40 @@
         "value": "67"
       }
     ],
+    "label_options": [
+      "certificate_origin",
+      "cost_center",
+      "delivery_confirmation",
+      "direct_delivery",
+      "duties_payment_account",
+      "duties_payment_country",
+      "duties_payment_type",
+      "duties_payment_zip",
+      "is_return",
+      "package_bill_type",
+      "payment_account",
+      "payment_country",
+      "payment_type",
+      "payment_zip",
+      "saturday_delivery",
+      "ship_date",
+      "shipper_currency",
+      "shipper_release",
+      "shipper_return_to_address",
+      "use_metric_units",
+      "usps_endorsement"
+    ],
+    "rate_options": [
+      "certificate_origin",
+      "delivery_confirmation",
+      "direct_delivery",
+      "package_bill_type",
+      "saturday_delivery",
+      "ship_date",
+      "shipper_currency",
+      "shipper_return_to_address",
+      "use_metric_units"
+    ],
     "shipping_method": [
       {
         "display": "UPS® Ground",
@@ -2988,7 +3022,7 @@
       "hazmat_type",
       "hazmat_electronics",
       "parcel_characteristics"
-    ]
+    ],
     "rate_options": [
       "service_type",
       "postal_reporting_number",

--- a/ShipperOptions.json
+++ b/ShipperOptions.json
@@ -4116,6 +4116,23 @@
         "display": "USPS® Small Flat Rate Envelope"
       }
     ],
+    "label_options": [
+      "amazon_order_id",
+      "arrive_by_date",
+      "carrier_pickup",
+      "delivery_confirmation",
+      "order_items",
+      "ship_date",
+      "shipping_method"
+    ],
+    "rate_options": [
+      "amazon_order_id",
+      "arrive_by_date",
+      "carrier_pickup",
+      "delivery_confirmation",
+      "order_items",
+      "ship_date"
+    ],
     "shipping_method": [
       {
         "value": "FEDEX_PTP_PRIORITY_OVERNIGHT",

--- a/ShipperOptions.json
+++ b/ShipperOptions.json
@@ -8,6 +8,8 @@
     "box_shape": [
       {"display": "Parcel", "value": "PKG"}
     ],
+    "label_options": ["delivery_confirmation", "ship_date", "service_token", "shipment_id"],
+    "rate_options": ["delivery_confirmation", "ship_date"],
     "shipping_method": [
       {"display": "Express Post", "value": "ExpressPost"},
       {"display": "Express Post", "value": "ExpressPostSignature"},
@@ -319,7 +321,7 @@
       "ship_date",
       "shipper_currency",
       "signature_service"
-    ]
+    ],
     "shipping_method": [
       {
         "value": "0",

--- a/build_python.sh
+++ b/build_python.sh
@@ -5,7 +5,7 @@ set -o errexit
 TAG="shipper-options-python"
 echo "Building package with params $@..."
 
-docker build -f Dockerfile-build-package --no-cache --tag "$TAG" .
+docker build --platform=linux/amd64 -f Dockerfile-build-package --no-cache --tag "$TAG" .
 docker run \
     --rm \
     "$TAG"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@ordoro/shipper-options",
-  "version": "1.22.1",
+  "version": "1.22.2",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ordoro/shipper-options",
-  "version": "1.22.1",
+  "version": "1.22.2",
   "description": "A collection of shipper options",
   "main": "ShipperOptions.json",
   "scripts": {


### PR DESCRIPTION
### pitney: rate label options

- also update python build, it was throwing a warning
ordoro/ordoro#14938

ordoro/shipper-options@a9339cf2ff86581e0150bfd3efbddc9e4ac9f2d0

___

### ups rate label options

ordoro/shipper-options@a3544a7365ddda06954367a76f2d36245229e2a9

___

### usps rate label options

ordoro/shipper-options@9da204392d243dc18789cec87c9d31018972d5f2

___

### amazon rate label options

ordoro/shipper-options@7ddc50f43114e6dad904521a79b8d1e735e11e0c

___

### amazon shipper rate label options

ordoro/shipper-options@eab33357b32fb4a6267b5ef156f621a910f12953

___

### canada post rate label options

ordoro/shipper-options@c7a703e866635b1698cbac78625fb70b0fe7cd0c

___

### dhl and dhl ecom rate label options

ordoro/shipper-options@3ae0c4998fc25ecded92c99c88ebc91e75e56474

___

### auspost rate label options

ordoro/shipper-options@730af3274c2c349c7e74e5bc62aed4617c511eef

___

### fedex 360 rate label options

ordoro/shipper-options@70b2c546b9d14ced63ba9bbf1f6fe6b104a87137

___

### pitney presort label options

ordoro/shipper-options@15620c42812d8906ebc2677da145975e44e402ca

___

### 1.22.2

ordoro/shipper-options@e634da606cc643b8d4472d5da8d5f79150597987