### PR TITLE
14059-Remove-One-Rate-Box-Shapes => main

### DIFF
--- a/ShipperOptions.json
+++ b/ShipperOptions.json
@@ -1107,20 +1107,17 @@
       {
         "display": "FedEx One Rate® - FedEx® Envelope",
         "value": "ONE_RATE_ENVELOPE",
-        "temp_use_fedex_auth": "comment property to make chopping easier",
-        "hide_for_csp": true
+        "deprecated": "2026-05-26"
       },
       {
         "display": "FedEx One Rate® - FedEx® Pak",
         "value": "ONE_RATE_PAK",
-        "temp_use_fedex_auth": "comment property to make chopping easier",
-        "hide_for_csp": true
+        "deprecated": "2026-05-26"
       },
       {
         "display": "FedEx One Rate® - FedEx® Tube",
         "value": "ONE_RATE_TUBE",
-        "temp_use_fedex_auth": "comment property to make chopping easier",
-        "hide_for_csp": true
+        "deprecated": "2026-05-26"
       },
       {
         "display": "FedEx® Extra Small Box",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@ordoro/shipper-options",
-  "version": "1.22.2",
+  "version": "1.23.0",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ordoro/shipper-options",
-  "version": "1.22.2",
+  "version": "1.23.0",
   "description": "A collection of shipper options",
   "main": "ShipperOptions.json",
   "scripts": {


### PR DESCRIPTION
### Move One Rate packages type to deprecated

- We need to hold on to these for package display name for old shipping
  labels

ordoro/ordoro#14059

ordoro/shipper-options@9c3c7bbc00e1ed776f3b0f8b726a4ba21968c558

___

### 1.23.0

ordoro/shipper-options@bd3f9efdc7dca0ddcb20a65b0942ab8f9afad14d