### PR TITLE
15069-shippo-insurance_type => main

### DIFF
--- a/ShipperOptions.json
+++ b/ShipperOptions.json
@@ -5317,7 +5317,7 @@
       }
     ],
     "label_options": [
-      "ship_date", "alternate_return_to_address", "alcohol_shipment_license", "ancillary_endorsement", "payor", "ignore_bad_address", "dangerous_goods_option", "dangerous_goods_code", "delivery_instructions", "saturday_delivery", "delivery_confirmation", "insurance", "rate_id", "shipment_id"
+      "ship_date", "alternate_return_to_address", "alcohol_shipment_license", "ancillary_endorsement", "payor", "ignore_bad_address", "dangerous_goods_option", "dangerous_goods_code", "delivery_instructions", "saturday_delivery", "delivery_confirmation", "insurance_type", "insured_value", "rate_id", "shipment_id"
     ],
     "payor": [
       {
@@ -5342,7 +5342,7 @@
       }
     ],
     "rate_options": [
-      "service_type", "ship_date", "alternate_return_to_address", "alcohol_shipment_license", "ancillary_endorsement", "payor", "ignore_bad_address", "dangerous_goods_option", "dangerous_goods_code", "delivery_instructions", "saturday_delivery", "delivery_confirmation", "insurance"
+      "service_type", "ship_date", "alternate_return_to_address", "alcohol_shipment_license", "ancillary_endorsement", "payor", "ignore_bad_address", "dangerous_goods_option", "dangerous_goods_code", "delivery_instructions", "saturday_delivery", "delivery_confirmation", "insurance_type", "insured_value"
     ],
     "reason_for_export": [
       {"value": "DOCUMENTS", "display": "Documents"},

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@ordoro/shipper-options",
-  "version": "1.23.1",
+  "version": "1.23.2",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ordoro/shipper-options",
-  "version": "1.23.1",
+  "version": "1.23.2",
   "description": "A collection of shipper options",
   "main": "ShipperOptions.json",
   "scripts": {


### PR DESCRIPTION
### shippo: change insurance to insurance_type

- remove the override in the api
- include insured_value here as that will also get sent in both rate and label requests
- this was previously missing info that would have been required when creating the shippo shipment
ordoro/ordoro#15069

ordoro/shipper-options@6d9bda9e779c6cf3b3e67cbe1a1ead8839d29885

___

### 1.23.2

ordoro/shipper-options@743bb01b796b22bf38a661287d4f2d89d7ccd38b